### PR TITLE
fix a crash error of "Attempt to access an null array"

### DIFF
--- a/word_list_sql_with_content_provider/app/src/main/java/com/android/example/wordlistsqlwithcontentprovider/WordListAdapter.java
+++ b/word_list_sql_with_content_provider/app/src/main/java/com/android/example/wordlistsqlwithcontentprovider/WordListAdapter.java
@@ -114,7 +114,7 @@ public class WordListAdapter extends RecyclerView.Adapter<WordListAdapter.WordVi
             public void onClick(View v) {
                 selectionArgs = new String[]{Integer.toString(id)};
                 int deleted = mContext.getContentResolver().delete(CONTENT_URI, CONTENT_PATH,
-                        selectionArgs);
+                        new String[]{String.valueof(id)});
                 if (deleted > 0) {
                     // Need both calls
                     notifyItemRemoved(h.getAdapterPosition());


### PR DESCRIPTION
Hi, I am new to Android and follow this practical to learn it. I when I have got to this practical, I find when I press the delete button of `MainActivity` an error happend at line 117 of `WordListAdapter.java` and the app crashed. I know the contentprovider will access the string array `selectionArgs`, but it seems to be null after initiaton. So I change the third positional argument of `mContext.getContentResolver().delete()` into `new String[]{String.valueof(id)}`. This works well. This is my first pull request. I hope I am not wrong.